### PR TITLE
docs: réécrire le README en français et le moderniser

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,50 +1,130 @@
-# wireguard-ui
+# WireGuard UI
 
-A web user interface to manage your WireGuard setup.
+Interface web moderne pour administrer un serveur WireGuard sans manipuler directement les fichiers de configuration.
 
-## Features
+## ✨ Fonctionnalités
 
-- Friendly UI
-- Authentication
-- Manage extra client's information (name, email, etc)
-- Retrieve configs using QR code / file
+- Gestion des pairs (création, édition, révocation).
+- Génération de configuration client.
+- Export via QR code et fichier.
+- Authentification administrateur.
+- Healthcheck API intégré (`/api/health`).
+- Déploiement simple avec Docker / Docker Compose.
 
-## Run WireGuard-UI
+## 🧱 Stack technique
 
-Default username and password are `admin`.
+- **Backend** : FastAPI (Python)
+- **Frontend** : Angular
+- **Base de données** : SQLite (par défaut, persistée dans `/data`)
+- **Conteneurisation** : Docker multi-stage (Node + Python + WireGuard tools)
 
-### Using docker compose
+## 🚀 Démarrage rapide (Docker Compose)
 
-You can take a look at this example of [docker-compose.yml](https://github.com/Cyr-ius/wireguard-ui/tree/master/example). Please adjust volume mount points to work with your setup. Then run it like below:
+### 1) Cloner le dépôt
 
-```
-docker-compose up
-```
-
-Note:
-
-There is a Status option that needs docker to be able to access the network of the host in order to read the
-wireguard interface stats. See the `cap_add` and `network_mode` options on the docker-compose.yaml
-
-### Environment Variables
-
-Set the `SESSION_SECRET` environment variable to a random value.
-
-In order to sent the wireguard configuration to clients via email set the following environment variables
-
-```
-USERNAME: your root account
-PASSWORD: your password account
-USER_MAIL: root's mail
-WIREGUARD_STARTUP:[True|False] Start wireguard at startup container
-SECURITY_TWO_FACTOR: [True|False] Enable OTP panel
-SECURITY_CHANGEABLE:[True|False] Enable Change password panel
-SECURITY_PASSWORD_LENGTH_MIN: Length password
-SECURITY_RECOVERABLE:[True|False] Enable recoverable account (send mail)
-SECURITY_REGISTERABLE:[True|False] Accept register account at login page (Strongly discouraged )
-SECURITY_CONFIRMABLE:[True|False] Confirm account A valid email address is required for root account
+```bash
+git clone https://github.com/cyr-ius/wireguard-ui.git
+cd wireguard-ui
 ```
 
-## License
+### 2) (Optionnel) Créer un fichier `.env`
 
-MIT. See [LICENSE](https://github.com/cyr-ius/wireguard-ui/blob/master/LICENSE).
+Le `docker-compose.yaml` fournit déjà des valeurs par défaut, mais il est recommandé de les surcharger en production :
+
+```env
+ADMIN_USERNAME=admin
+ADMIN_PASSWORD=change-me-now
+SECRET_KEY=replace-with-a-long-random-secret
+LOG_LEVEL=INFO
+```
+
+### 3) Lancer l’application
+
+```bash
+docker compose up -d --build
+```
+
+### 4) Accéder à l’interface
+
+- UI / API : `http://localhost:8000`
+- Port WireGuard : `51820/udp`
+
+## 🔐 Variables d’environnement importantes
+
+### Sécurité / Auth
+
+- `ADMIN_USERNAME` : identifiant admin initial.
+- `ADMIN_PASSWORD` : mot de passe admin initial.
+- `ADMIN_EMAIL` : email admin initial.
+- `SECRET_KEY` : clé de signature JWT (**obligatoire en production**).
+- `ACCESS_TOKEN_EXPIRE_MINUTES` : durée de vie des tokens.
+- `BCRYPT_ROUNDS` : coût de hash des mots de passe.
+
+### API / Application
+
+- `LOG_LEVEL` : niveau de logs (`INFO`, `DEBUG`, etc.).
+- `APP_VERSION` : version exposée par l’application.
+- `ALLOWED_ORIGINS` : origines CORS autorisées (séparées par des virgules).
+- `FRONTEND_DIST` : chemin du build frontend servi en statique.
+
+### Base de données
+
+- `DATABASE_URL` : URL de connexion SQLAlchemy.
+  - Par défaut : `sqlite+aiosqlite:////data/wireguard_ui.db`
+
+### WireGuard
+
+- `WIREGUARD_AUTOSTART` : active le démarrage automatique WireGuard au lancement.
+
+### Email (envoi de configuration / notifications)
+
+- `MAIL_FROM` : adresse expéditrice.
+- `MAIL_NAME` : nom expéditeur.
+
+> D’autres réglages SMTP sont configurables depuis l’interface d’administration.
+
+## 🩺 Santé de service
+
+Le conteneur expose un healthcheck sur :
+
+```text
+GET /api/health
+```
+
+Exemple :
+
+```bash
+curl -f http://localhost:8000/api/health
+```
+
+## 📦 Persistance des données
+
+Le volume `wireguard-ui_data` est monté sur `/data` dans le conteneur.
+
+- Base SQLite
+- État applicatif persistant
+
+## 🛡️ Recommandations production
+
+- Remplacer `SECRET_KEY` par une valeur longue et aléatoire.
+- Changer immédiatement les identifiants admin par défaut.
+- Restreindre `ALLOWED_ORIGINS` à vos domaines.
+- Utiliser un reverse proxy TLS (Traefik, Nginx, Caddy).
+- Sauvegarder régulièrement le volume `/data`.
+
+## 🧪 Développement local (sans Docker)
+
+Le projet contient :
+
+- `backend/` (FastAPI)
+- `frontend/` (Angular)
+
+Vous pouvez lancer chaque partie indépendamment selon votre workflow (Node/Python).
+
+## 🤝 Crédits
+
+Ce README a été restructuré dans un format inspiré des projets de l’écosystème **cyr-ius** (ex : PortalCrane), avec une organisation orientée onboarding et exploitation.
+
+## 📄 Licence
+
+MIT — voir [LICENSE](LICENSE).


### PR DESCRIPTION
### Motivation
- Améliorer l'onboarding et l'exploitation en remplaçant le README minimal par une documentation claire et structurée en français.
- Aligner la documentation avec la configuration actuelle du projet (Docker Compose, `API /api/health`, volume `/data`, variables d'environnement modernes).
- Fournir des recommandations de production et un guide de démarrage rapide inspiré par les projets du même auteur pour faciliter le déploiement.

### Description
- Remplacement complet de `README.md` par une version en français organisée en sections : fonctionnalités, stack, quickstart, variables d'environnement, healthcheck, persistance, recommandations production et dev local.
- Ajout d'un guide rapide Docker Compose avec exemples d'`.env` et des chemins d'accès (UI/API `http://localhost:8000`, port WireGuard `51820/udp`).
- Documentation des variables importantes utilisées par l'application, notamment `ADMIN_USERNAME`, `ADMIN_PASSWORD`, `SECRET_KEY`, `DATABASE_URL`, `WIREGUARD_AUTOSTART` et paramètres mail (`MAIL_FROM`, `MAIL_NAME`).
- Ajout d'une section « Santé de service » indiquant le healthcheck `GET /api/health` et d'une section crédits/licence (MIT).

### Testing
- Vérification automatisée du diff et de la présence des nouvelles sections en comparant l'ancien et le nouveau `README.md`, réussite.
- Inspection automatisée du contenu ligne-par-ligne (`nl`) pour valider la structure et les en-têtes, réussite.
- Tentative automatisée de récupération du README de référence (`cyr-ius/portalcrane`) échouée pour cause réseau (`CONNECT tunnel failed, response 403`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cacdca8b208330ab917e32e9b547dc)