### PR TITLE
fix(theme): remplacer couleurs light hardcodées par variables CSS

### DIFF
--- a/frontend/src/app/features/oidc/oidc.component.css
+++ b/frontend/src/app/features/oidc/oidc.component.css
@@ -32,7 +32,7 @@
   align-items: center;
   gap: 1rem;
   padding: 3rem;
-  color: #64748b;
+  color: var(--text-muted);
 }
 
 .config-form {
@@ -42,8 +42,8 @@
 }
 
 .config-card {
-  background: #fff;
-  border: 1px solid #e2e8f0;
+  background: var(--panel-bg);
+  border: 1px solid var(--border-color);
   border-radius: 14px;
   padding: 1.5rem;
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.05);
@@ -52,10 +52,10 @@
 .section-title {
   font-size: 0.95rem;
   font-weight: 700;
-  color: #1e293b;
+  color: var(--text-primary);
   margin-bottom: 1.25rem;
   padding-bottom: 0.75rem;
-  border-bottom: 2px solid #f1f5f9;
+  border-bottom: 2px solid var(--panel-bg-alt);
 }
 
 .form-row {
@@ -71,7 +71,7 @@
 .form-label {
   font-size: 0.78rem;
   font-weight: 600;
-  color: #64748b;
+  color: var(--text-muted);
   text-transform: uppercase;
   letter-spacing: 0.05em;
   margin-bottom: 0.4rem;
@@ -80,7 +80,7 @@
 
 .form-control {
   border-radius: 8px;
-  border: 1px solid #e2e8f0;
+  border: 1px solid var(--border-color);
   font-size: 0.875rem;
   transition: border-color 150ms;
 }

--- a/frontend/src/app/features/server/server.component.css
+++ b/frontend/src/app/features/server/server.component.css
@@ -13,13 +13,13 @@
 .page-container .page-header .page-title {
   font-size: 1.5rem;
   font-weight: 800;
-  color: #1e293b;
+  color: var(--text-primary);
   margin: 0;
   letter-spacing: -0.02em;
 }
 .page-container .page-header .page-subtitle {
   font-size: 0.85rem;
-  color: #64748b;
+  color: var(--text-muted);
   margin: 0.25rem 0 0;
 }
 .page-container .service-controls {
@@ -33,7 +33,7 @@
   align-items: center;
   gap: 1rem;
   padding: 3rem;
-  color: #64748b;
+  color: var(--text-muted);
 }
 
 .page-title {
@@ -56,8 +56,8 @@
   gap: 1.5rem;
 }
 .config-form .config-card {
-  background: #fff;
-  border: 1px solid #e2e8f0;
+  background: var(--panel-bg);
+  border: 1px solid var(--border-color);
   border-radius: 14px;
   padding: 1.5rem;
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.05);
@@ -65,10 +65,10 @@
 .config-form .config-card .section-title {
   font-size: 0.95rem;
   font-weight: 700;
-  color: #1e293b;
+  color: var(--text-primary);
   margin-bottom: 1.25rem;
   padding-bottom: 0.75rem;
-  border-bottom: 2px solid #f1f5f9;
+  border-bottom: 2px solid var(--panel-bg-alt);
 }
 .config-form .form-row {
   display: grid;
@@ -86,7 +86,7 @@
 .config-form .form-label {
   font-size: 0.78rem;
   font-weight: 600;
-  color: #64748b;
+  color: var(--text-muted);
   text-transform: uppercase;
   letter-spacing: 0.05em;
   margin-bottom: 0.4rem;
@@ -94,7 +94,7 @@
 }
 .config-form .form-control {
   border-radius: 8px;
-  border: 1px solid #e2e8f0;
+  border: 1px solid var(--border-color);
   font-size: 0.875rem;
   transition: border-color 150ms;
 }

--- a/frontend/src/app/features/settings/settings.component.css
+++ b/frontend/src/app/features/settings/settings.component.css
@@ -13,13 +13,13 @@
 .page-container .page-header .page-title {
   font-size: 1.5rem;
   font-weight: 800;
-  color: #1e293b;
+  color: var(--text-primary);
   margin: 0;
   letter-spacing: -0.02em;
 }
 .page-container .page-header .page-subtitle {
   font-size: 0.85rem;
-  color: #64748b;
+  color: var(--text-muted);
   margin: 0.25rem 0 0;
 }
 .page-container .loading-state {
@@ -28,7 +28,7 @@
   align-items: center;
   gap: 1rem;
   padding: 3rem;
-  color: #64748b;
+  color: var(--text-muted);
 }
 .page-title {
   font-family: "Courier New", monospace;
@@ -49,8 +49,8 @@
   gap: 1.5rem;
 }
 .config-form .config-card {
-  background: #fff;
-  border: 1px solid #e2e8f0;
+  background: var(--panel-bg);
+  border: 1px solid var(--border-color);
   border-radius: 14px;
   padding: 1.5rem;
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.05);
@@ -58,10 +58,10 @@
 .config-form .config-card .section-title {
   font-size: 0.95rem;
   font-weight: 700;
-  color: #1e293b;
+  color: var(--text-primary);
   margin-bottom: 1.25rem;
   padding-bottom: 0.75rem;
-  border-bottom: 2px solid #f1f5f9;
+  border-bottom: 2px solid var(--panel-bg-alt);
 }
 .config-form .form-row {
   display: grid;
@@ -79,7 +79,7 @@
 .config-form .form-label {
   font-size: 0.78rem;
   font-weight: 600;
-  color: #64748b;
+  color: var(--text-muted);
   text-transform: uppercase;
   letter-spacing: 0.05em;
   margin-bottom: 0.4rem;
@@ -87,7 +87,7 @@
 }
 .config-form .form-control {
   border-radius: 8px;
-  border: 1px solid #e2e8f0;
+  border: 1px solid var(--border-color);
   font-size: 0.875rem;
   transition: border-color 150ms;
 }

--- a/frontend/src/app/features/smtp/smtp.component.css
+++ b/frontend/src/app/features/smtp/smtp.component.css
@@ -13,13 +13,13 @@
 .page-container .page-header .page-title {
   font-size: 1.5rem;
   font-weight: 800;
-  color: #1e293b;
+  color: var(--text-primary);
   margin: 0;
   letter-spacing: -0.02em;
 }
 .page-container .page-header .page-subtitle {
   font-size: 0.85rem;
-  color: #64748b;
+  color: var(--text-muted);
   margin: 0.25rem 0 0;
 }
 .page-container .service-controls {
@@ -33,7 +33,7 @@
   align-items: center;
   gap: 1rem;
   padding: 3rem;
-  color: #64748b;
+  color: var(--text-muted);
 }
 
 .page-title {
@@ -56,8 +56,8 @@
   gap: 1.5rem;
 }
 .config-form .config-card {
-  background: #fff;
-  border: 1px solid #e2e8f0;
+  background: var(--panel-bg);
+  border: 1px solid var(--border-color);
   border-radius: 14px;
   padding: 1.5rem;
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.05);
@@ -65,10 +65,10 @@
 .config-form .config-card .section-title {
   font-size: 0.95rem;
   font-weight: 700;
-  color: #1e293b;
+  color: var(--text-primary);
   margin-bottom: 1.25rem;
   padding-bottom: 0.75rem;
-  border-bottom: 2px solid #f1f5f9;
+  border-bottom: 2px solid var(--panel-bg-alt);
 }
 .config-form .form-row {
   display: grid;
@@ -86,7 +86,7 @@
 .config-form .form-label {
   font-size: 0.78rem;
   font-weight: 600;
-  color: #64748b;
+  color: var(--text-muted);
   text-transform: uppercase;
   letter-spacing: 0.05em;
   margin-bottom: 0.4rem;
@@ -94,7 +94,7 @@
 }
 .config-form .form-control {
   border-radius: 8px;
-  border: 1px solid #e2e8f0;
+  border: 1px solid var(--border-color);
   font-size: 0.875rem;
   transition: border-color 150ms;
 }
@@ -131,10 +131,10 @@
 
 .test-modal__card {
   width: min(100%, 640px);
-  background: #ffffff;
+  background: var(--panel-bg);
   border-radius: 18px;
   box-shadow: 0 24px 80px rgba(15, 23, 42, 0.24);
-  border: 1px solid #e2e8f0;
+  border: 1px solid var(--border-color);
   position: relative;
   z-index: 1056;
 }
@@ -149,7 +149,7 @@
 }
 
 .test-modal__header {
-  border-bottom: 1px solid #e2e8f0;
+  border-bottom: 1px solid var(--border-color);
 }
 
 .test-modal__body {
@@ -160,17 +160,17 @@
   margin: 0;
   font-size: 1.1rem;
   font-weight: 700;
-  color: #0f172a;
+  color: var(--text-primary);
 }
 
 .test-modal__subtitle {
   margin: 0.35rem 0 0;
-  color: #64748b;
+  color: var(--text-muted);
   font-size: 0.9rem;
 }
 
 .test-modal__actions {
-  border-top: 1px solid #e2e8f0;
+  border-top: 1px solid var(--border-color);
   justify-content: flex-end;
 }
 
@@ -178,9 +178,9 @@
   margin-top: 1rem;
   padding: 1rem;
   border-radius: 14px;
-  border: 1px solid #dbeafe;
-  background: linear-gradient(180deg, #f8fbff 0%, #eff6ff 100%);
-  color: #1e293b;
+  border: 1px solid var(--border-color);
+  background: var(--panel-bg-alt);
+  color: var(--text-primary);
 }
 
 .mail-preview p:last-child {

--- a/frontend/src/app/features/users/users.component.css
+++ b/frontend/src/app/features/users/users.component.css
@@ -12,13 +12,13 @@
 .page-container .page-header .page-title {
   font-size: 1.5rem;
   font-weight: 800;
-  color: #1e293b;
+  color: var(--text-primary);
   margin: 0;
   letter-spacing: -0.02em;
 }
 .page-container .page-header .page-subtitle {
   font-size: 0.85rem;
-  color: #64748b;
+  color: var(--text-muted);
   margin: 0.25rem 0 0;
 }
 .page-container .loading-state {
@@ -27,7 +27,7 @@
   align-items: center;
   gap: 1rem;
   padding: 3rem;
-  color: #64748b;
+  color: var(--text-muted);
 }
 .page-title {
   font-family: "Courier New", monospace;
@@ -43,8 +43,8 @@
   margin: 0;
 }
 .content-card {
-  background: #fff;
-  border: 1px solid #e2e8f0;
+  background: var(--panel-bg);
+  border: 1px solid var(--border-color);
   border-radius: 14px;
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.05);
   overflow: hidden;
@@ -58,18 +58,18 @@
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.06em;
-  color: #94a3b8;
+  color: var(--text-subtle);
   padding: 0.875rem 1rem;
-  border-bottom: 2px solid #f1f5f9;
-  background: #fafafa;
+  border-bottom: 2px solid var(--panel-bg-alt);
+  background: var(--panel-bg-alt);
 }
 .users-table td {
   padding: 0.875rem 1rem;
   vertical-align: middle;
-  color: #334155;
+  color: var(--text-secondary);
 }
 .users-table tr:hover td {
-  background: #f8fafc;
+  background: var(--panel-bg-alt);
 }
 
 .user-cell {
@@ -96,7 +96,7 @@
 }
 .user-cell .user-username {
   font-size: 0.75rem;
-  color: #94a3b8;
+  color: var(--text-subtle);
 }
 
 .role-tags {
@@ -111,8 +111,8 @@
   letter-spacing: 0.06em;
   border-radius: 6px;
   padding: 0.15rem 0.5rem;
-  background: #f1f5f9;
-  color: #64748b;
+  background: var(--panel-bg-alt);
+  color: var(--text-muted);
 }
 .role-tags .role-tag.role-admin {
   background: rgba(0, 180, 216, 0.12);
@@ -133,7 +133,7 @@
 }
 .status-pill.inactive {
   background: rgba(148, 163, 184, 0.1);
-  color: #64748b;
+  color: var(--text-muted);
 }
 
 .table-actions {
@@ -142,8 +142,8 @@
 }
 
 .action-btn {
-  background: #fff;
-  border: 1px solid #e2e8f0;
+  background: var(--panel-bg);
+  border: 1px solid var(--border-color);
   border-radius: 7px;
   width: 32px;
   height: 32px;
@@ -151,7 +151,7 @@
   align-items: center;
   justify-content: center;
   font-size: 0.8rem;
-  color: #64748b;
+  color: var(--text-muted);
   cursor: pointer;
   transition: all 150ms ease;
 }
@@ -187,7 +187,7 @@
   }
 }
 .modal-panel {
-  background: #fff;
+  background: var(--panel-bg);
   border-radius: 16px;
   width: 100%;
   max-width: 600px;
@@ -205,29 +205,29 @@
   align-items: center;
   justify-content: space-between;
   padding: 1.25rem 1.5rem;
-  border-bottom: 1px solid #f1f5f9;
+  border-bottom: 1px solid var(--panel-bg-alt);
   position: sticky;
   top: 0;
-  background: #fff;
+  background: var(--panel-bg);
 }
 .modal-panel .modal-header .modal-title {
   font-size: 1.1rem;
   font-weight: 700;
-  color: #1e293b;
+  color: var(--text-primary);
   margin: 0;
 }
 .modal-panel .modal-header .modal-close {
   background: none;
   border: none;
-  color: #94a3b8;
+  color: var(--text-subtle);
   cursor: pointer;
   font-size: 1rem;
   border-radius: 6px;
   padding: 0.25rem;
 }
 .modal-panel .modal-header .modal-close:hover {
-  color: #1e293b;
-  background: #f1f5f9;
+  color: var(--text-primary);
+  background: var(--panel-bg-alt);
 }
 .modal-panel .modal-form {
   padding: 1.5rem;
@@ -249,7 +249,7 @@
 .modal-panel .form-label {
   font-size: 0.78rem;
   font-weight: 600;
-  color: #64748b;
+  color: var(--text-muted);
   text-transform: uppercase;
   letter-spacing: 0.05em;
   margin-bottom: 0.4rem;
@@ -257,7 +257,7 @@
 }
 .modal-panel .form-control {
   border-radius: 8px;
-  border: 1px solid #e2e8f0;
+  border: 1px solid var(--border-color);
   font-size: 0.875rem;
 }
 .modal-panel .form-control:focus {
@@ -268,7 +268,7 @@
   border-color: #ef4444;
 }
 .modal-panel .form-control[readonly] {
-  background: #f8fafc;
+  background: var(--panel-bg-alt);
 }
 .modal-panel .form-error {
   font-size: 0.72rem;
@@ -285,7 +285,7 @@
   align-items: center;
   gap: 0.5rem;
   padding: 0.6rem 0.875rem;
-  border: 1px solid #e2e8f0;
+  border: 1px solid var(--border-color);
   border-radius: 8px;
   cursor: pointer;
   font-size: 0.875rem;
@@ -294,7 +294,7 @@
 }
 .modal-panel .role-checkboxes .role-checkbox small {
   font-weight: 400;
-  color: #94a3b8;
+  color: var(--text-subtle);
   margin-left: auto;
   font-size: 0.75rem;
 }
@@ -314,7 +314,7 @@
   justify-content: flex-end;
   gap: 0.75rem;
   padding-top: 1rem;
-  border-top: 1px solid #f1f5f9;
+  border-top: 1px solid var(--panel-bg-alt);
   margin-top: 0.5rem;
 }
 
@@ -336,11 +336,11 @@
 .confirm-title {
   font-size: 1.2rem;
   font-weight: 700;
-  color: #1e293b;
+  color: var(--text-primary);
 }
 
 .confirm-msg {
   font-size: 0.875rem;
-  color: #64748b;
+  color: var(--text-muted);
   margin-bottom: 1.5rem;
 }


### PR DESCRIPTION
### Motivation
- Corriger le rendu cassé en thème sombre causé par des couleurs « light » codées en dur (`#fff`, `#e2e8f0`, `#1e293b`, etc.) utilisées dans plusieurs pages de configuration. 
- Uniformiser l'apparence en utilisant les variables de thème définies dans `frontend/src/styles.css` pour que les pages respectent `data-theme` (light/dark).

### Description
- Remplacement des couleurs light hardcodées par des tokens de thème dans les feuilles de style des vues suivantes : `frontend/src/app/features/users/users.component.css`, `frontend/src/app/features/oidc/oidc.component.css`, `frontend/src/app/features/settings/settings.component.css`, `frontend/src/app/features/smtp/smtp.component.css`, et `frontend/src/app/features/server/server.component.css`.
- Principaux remplacements : `#fff`/`#ffffff` → `var(--panel-bg)`, `#e2e8f0`/autres bordures claires → `var(--border-color)`, `#1e293b`/autres textes foncés → `var(--text-primary)`, et variantes pour `var(--panel-bg-alt)`, `var(--text-muted)`, `var(--text-secondary)`, `var(--text-subtle)`.
- Correction spécifique pour SMTP : la carte de test (`.test-modal__card`) et le bloc `mail-preview` utilisent maintenant des tokens de thème (fond, bordure, couleur de texte) au lieu d'un gradient / bordures light fixes.
- Conserver `#fff` pour le texte des initiales de l'avatar dans la table utilisateurs afin de préserver le contraste sur le gradient accent.

### Testing
- Vérification de l'étendue des remplacements avec `rg`/recherche automatique pour les patterns ciblés, confirmant que les occurrences light ont été remplacées sauf le `#fff` volontaire pour l'avatar (succès).
- Tentative de build frontend avec `npm run build` dans `frontend/` (échoue dans cet environnement car la CLI Angular n'est pas installée; `ng: not found`).
- Les changements ont été commités localement (5 fichiers modifiés).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cad192f01c833091faa9506331aa78)