### PR TITLE
Fix file handle leak, robust SMTP settings fetch, and deduplicate QR generation

### DIFF
--- a/backend/src/routers/clients.py
+++ b/backend/src/routers/clients.py
@@ -2,11 +2,8 @@
 
 from __future__ import annotations
 
-import base64
-import io
 import logging
 
-import qrcode
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, status
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
@@ -25,6 +22,7 @@ from ..schemas import (
 )
 from ..services.email import SupportedLanguage, send_client_config_email
 from ..services.ip_suggestion import suggest_next_ip
+from ..services.qr import generate_qr_code_base64
 from ..services.wireguard import (
     WireGuardError,
     build_client_config,
@@ -35,32 +33,6 @@ from ..services.wireguard import (
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
-
-
-def _generate_qr_code_base64(config_content: str) -> str:
-    """Generate a QR code image from WireGuard config and return as base64 string.
-
-    Args:
-        config_content: WireGuard configuration file content.
-
-    Returns:
-        str: Base64-encoded PNG image.
-    """
-    qr = qrcode.QRCode(
-        version=None,
-        error_correction=qrcode.ERROR_CORRECT_L,
-        box_size=6,
-        border=4,
-    )
-    qr.add_data(config_content)
-    qr.make(fit=True)
-
-    img = qr.make_image(fill_color="black", back_color="white")
-    buffer = io.BytesIO()
-    img.save(buffer, "PNG")
-    buffer.seek(0)
-
-    return base64.b64encode(buffer.getvalue()).decode("utf-8")
 
 
 @router.get("", response_model=list[ClientResponse])
@@ -263,7 +235,7 @@ async def get_client_config(
         raise HTTPException(400, detail="Settings not configured")
 
     config_content = build_client_config(client, server, settings)
-    qr_code_base64 = _generate_qr_code_base64(config_content)
+    qr_code_base64 = generate_qr_code_base64(config_content)
 
     return ClientConfigResponse(
         client_id=client_id,

--- a/backend/src/routers/smtp.py
+++ b/backend/src/routers/smtp.py
@@ -98,7 +98,12 @@ async def _get_settings(db: AsyncSession) -> GlobalSettings:
     Returns:
         GlobalSettings: The settings ORM object.
     """
-    settings = (await db.exec(select(GlobalSettings))).one()
+    settings = (await db.exec(select(GlobalSettings))).one_or_none()
+    if settings is None:
+        settings = GlobalSettings()
+        db.add(settings)
+        await db.commit()
+        await db.refresh(settings)
     return settings
 
 

--- a/backend/src/services/email.py
+++ b/backend/src/services/email.py
@@ -5,13 +5,11 @@ Supports multilingual templates (en, fr, es) with QR code and config file attach
 
 from __future__ import annotations
 
-import base64
 import io
 import logging
 from pathlib import Path
 from typing import Literal, cast
 
-import qrcode
 from email_validator import EmailNotValidError, validate_email
 from fastapi_mail import (
     ConnectionConfig,
@@ -25,6 +23,7 @@ from pydantic import SecretStr
 from starlette.datastructures import Headers, UploadFile
 
 from ..models import GlobalSettings, WireGuardClient, WireGuardServer
+from .qr import generate_qr_code_base64
 
 logger = logging.getLogger(__name__)
 
@@ -33,32 +32,6 @@ TEMPLATES_DIR = Path(__file__).resolve().parent.parent / "templates"
 
 # Supported language codes for email templates
 SupportedLanguage = Literal["en", "fr", "es"]
-
-
-def _generate_qr_code_base64(config_content: str) -> str:
-    """Generate a QR code from WireGuard config content and return it as base64 PNG.
-
-    Args:
-        config_content: The WireGuard configuration file content.
-
-    Returns:
-        str: Base64-encoded PNG image of the QR code.
-    """
-    qr = qrcode.QRCode(
-        version=None,
-        error_correction=qrcode.ERROR_CORRECT_L,
-        box_size=6,
-        border=4,
-    )
-    qr.add_data(config_content)
-    qr.make(fit=True)
-
-    img = qr.make_image(fill_color="black", back_color="white")
-    buffer = io.BytesIO()
-    img.save(buffer, "PNG")
-    buffer.seek(0)
-
-    return base64.b64encode(buffer.getvalue()).decode("utf-8")
 
 
 def _resolve_mail_from(settings: GlobalSettings) -> str:
@@ -139,7 +112,7 @@ async def send_client_config_email(
         raise ValueError("SMTP server is not configured in global settings.")
 
     # Generate QR code from config content
-    qr_code_base64 = _generate_qr_code_base64(config_content)
+    qr_code_base64 = generate_qr_code_base64(config_content)
 
     # Render HTML template
     html_content = _render_email_template(language, client, qr_code_base64, settings)

--- a/backend/src/services/qr.py
+++ b/backend/src/services/qr.py
@@ -1,0 +1,27 @@
+"""QR code helpers shared across routers and services."""
+
+from __future__ import annotations
+
+import base64
+import io
+
+import qrcode
+
+
+def generate_qr_code_base64(content: str) -> str:
+    """Generate a QR code image and return it as base64-encoded PNG."""
+    qr = qrcode.QRCode(
+        version=None,
+        error_correction=qrcode.ERROR_CORRECT_L,
+        box_size=6,
+        border=4,
+    )
+    qr.add_data(content)
+    qr.make(fit=True)
+
+    image = qr.make_image(fill_color="black", back_color="white")
+    buffer = io.BytesIO()
+    image.save(buffer, "PNG")
+    buffer.seek(0)
+
+    return base64.b64encode(buffer.getvalue()).decode("utf-8")

--- a/backend/src/services/wireguard.py
+++ b/backend/src/services/wireguard.py
@@ -205,11 +205,18 @@ async def write_server_config(
     settings: GlobalSettings,
 ) -> None:
     """Write the server config file to disk (async executor to avoid blocking)."""
+
+    def _write_config_file(path: str, data: str) -> None:
+        with open(path, "w", encoding="utf-8") as config_file:
+            config_file.write(data)
+
     content = build_server_config(server, clients, settings)
     loop = asyncio.get_event_loop()
     await loop.run_in_executor(
         None,
-        lambda: open(settings.config_file_path, "w").write(content),
+        _write_config_file,
+        settings.config_file_path,
+        content,
     )
 
 


### PR DESCRIPTION
### Motivation
- Prevent an unclosed file descriptor when writing the WireGuard server config by ensuring the file is written with a context manager executed in the threadpool. 
- Avoid runtime errors in SMTP settings lookup when no `GlobalSettings` row exists. 
- Remove duplicated QR code generation logic to centralize behavior and reduce maintenance cost.

### Description
- Replace the inline `open(...).write(...)` call in `write_server_config` with a `_write_config_file` helper that uses `with open(..., encoding='utf-8')` and run it via `loop.run_in_executor` to guarantee the file is closed. (`backend/src/services/wireguard.py`).
- Make `_get_settings` resilient by using `.one_or_none()` and create/persist a default `GlobalSettings()` row when no settings exist. (`backend/src/routers/smtp.py`).
- Add a shared `generate_qr_code_base64` helper in `backend/src/services/qr.py` and replace duplicated QR logic in both `backend/src/routers/clients.py` and `backend/src/services/email.py` to use the shared function. (`backend/src/services/qr.py`, `backend/src/routers/clients.py`, `backend/src/services/email.py`).

### Testing
- Ran `python -m compileall backend/src` and it completed successfully, producing compiled bytecode for the modified modules. 
- Ran a linter check attempt (`uv run ruff check src`) but it could not complete in this environment due to a dependency download failure for `bcrypt` (network/tunnel error), so linting could not be fully validated here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc0c5d830c83308d86dcc09423a367)