### PR TITLE
Log exceptions and return generic errors for WireGuard server and SMTP routers

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ Les contributions sont bienvenues : bugfix, amélioration UX, sécurité, docume
    ```
 2. Développer avec des commits atomiques et des messages explicites.
 3. Vérifier localement avant PR :
+
    ```bash
    # Backend
    cd backend
@@ -179,6 +180,7 @@ Les contributions sont bienvenues : bugfix, amélioration UX, sécurité, docume
    cd ../frontend
    npm run build
    ```
+
 4. Ouvrir une Pull Request avec :
    - le contexte / problème,
    - la solution proposée,

--- a/backend/src/routers/server.py
+++ b/backend/src/routers/server.py
@@ -1,5 +1,7 @@
 """WireGuard server configuration and service control router."""
 
+import logging
+
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlmodel import delete, select
 from sqlmodel.ext.asyncio.session import AsyncSession
@@ -18,6 +20,7 @@ from ..services.wireguard import (
 )
 
 router = APIRouter()
+logger = logging.getLogger(__name__)
 
 
 @router.get("", response_model=ServerResponse)
@@ -84,9 +87,15 @@ async def apply_config(
         await write_server_config(s, clients, settings)
         await restart_service()
     except WireGuardError as exc:
-        raise HTTPException(500, detail=str(exc))
+        logger.exception("WireGuard apply config failed: %s", exc)
+        raise HTTPException(
+            500, detail="Failed to apply WireGuard configuration. Check server logs."
+        )
     except Exception as exc:
-        raise HTTPException(500, detail=f"Failed to apply config: {exc}")
+        logger.exception("Unexpected error while applying WireGuard config: %s", exc)
+        raise HTTPException(
+            500, detail="Failed to apply WireGuard configuration. Check server logs."
+        )
 
 
 @router.post("/service/{action}", status_code=status.HTTP_204_NO_CONTENT)
@@ -103,4 +112,7 @@ async def control_service(action: str, _: User = Depends(get_current_admin)):
             case _:
                 raise HTTPException(400, detail=f"Unknown action: {action}")
     except WireGuardError as exc:
-        raise HTTPException(500, detail=str(exc))
+        logger.exception("WireGuard service action '%s' failed: %s", action, exc)
+        raise HTTPException(
+            500, detail="WireGuard service action failed. Check server logs."
+        )

--- a/backend/src/routers/smtp.py
+++ b/backend/src/routers/smtp.py
@@ -224,5 +224,7 @@ async def test_smtp_settings(
         logger.info("SMTP test email scheduled to %s", body.recipient)
 
     except Exception as exc:
-        logger.error("SMTP test failed: %s", exc)
-        raise HTTPException(500, detail=f"SMTP test failed: {exc!s}")
+        logger.exception("SMTP test failed: %s", exc)
+        raise HTTPException(
+            500, detail="SMTP test failed due to an internal error. Check server logs."
+        )


### PR DESCRIPTION
### Motivation
- Improve observability by logging full exception details server-side while avoiding leaking internal error strings to API clients.
- Provide clearer, consistent error messages for the WireGuard server control/apply flows and SMTP test endpoint.

### Description
- Added `import logging` and a module `logger = logging.getLogger(__name__)` in `backend/src/routers/server.py` and switched internal error handling to call `logger.exception(...)` before raising a generic `HTTPException` for `apply_config` and `control_service` paths.
- Replaced direct exception detail exposure with a generic message: "Failed to apply WireGuard configuration. Check server logs." and "WireGuard service action failed. Check server logs." in `server.py`.
- In `backend/src/routers/smtp.py` replaced `logger.error(...)` with `logger.exception(...)` and return a generic `HTTPException` detail: "SMTP test failed due to an internal error. Check server logs.".
- No changes to successful control flows or service behavior; only error logging/detail responses were modified.

### Testing
- Ran the test suite with `pytest` and all tests completed successfully.
- Ran style/type checks with `flake8` and `mypy` and no new issues were reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc327fa62c8330ac63b405a085341a)