### PR TITLE
Add uniqueness checks, improve logging/error messages, and optimize role loading

### DIFF
--- a/backend/src/routers/clients.py
+++ b/backend/src/routers/clients.py
@@ -204,7 +204,9 @@ async def update_client(
         if payload[field_name] == getattr(c, field_name):
             continue
         existing = (
-            await db.exec(select(WireGuardClient).where(model_field == payload[field_name]))
+            await db.exec(
+                select(WireGuardClient).where(model_field == payload[field_name])
+            )
         ).one_or_none()
         if existing:
             raise HTTPException(422, detail=message)

--- a/backend/src/routers/clients.py
+++ b/backend/src/routers/clients.py
@@ -191,7 +191,25 @@ async def update_client(
     c = await db.get(WireGuardClient, client_id)
     if not c:
         raise HTTPException(404, detail="Client not found")
-    c.sqlmodel_update(data.model_dump(exclude_unset=True))
+
+    payload = data.model_dump(exclude_unset=True)
+    unique_checks = [
+        ("name", WireGuardClient.name, "Client name already in use"),
+        ("email", WireGuardClient.email, "Email address already in use"),
+        ("allocated_ips", WireGuardClient.allocated_ips, "IP address already in use"),
+    ]
+    for field_name, model_field, message in unique_checks:
+        if field_name not in payload:
+            continue
+        if payload[field_name] == getattr(c, field_name):
+            continue
+        existing = (
+            await db.exec(select(WireGuardClient).where(model_field == payload[field_name]))
+        ).one_or_none()
+        if existing:
+            raise HTTPException(422, detail=message)
+
+    c.sqlmodel_update(payload)
     db.add(c)
     await db.commit()
     await db.refresh(c)

--- a/backend/src/routers/server.py
+++ b/backend/src/routers/server.py
@@ -1,5 +1,7 @@
 """WireGuard server configuration and service control router."""
 
+import logging
+
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlmodel import delete, select
 from sqlmodel.ext.asyncio.session import AsyncSession
@@ -18,6 +20,7 @@ from ..services.wireguard import (
 )
 
 router = APIRouter()
+logger = logging.getLogger(__name__)
 
 
 @router.get("", response_model=ServerResponse)
@@ -84,9 +87,15 @@ async def apply_config(
         await write_server_config(s, clients, settings)
         await restart_service()
     except WireGuardError as exc:
-        raise HTTPException(500, detail=str(exc))
+        logger.exception("WireGuard apply config failed: %s", exc)
+        raise HTTPException(
+            500, detail="Failed to apply WireGuard configuration. Check server logs."
+        )
     except Exception as exc:
-        raise HTTPException(500, detail=f"Failed to apply config: {exc}")
+        logger.exception("Unexpected error while applying WireGuard config: %s", exc)
+        raise HTTPException(
+            500, detail="Failed to apply WireGuard configuration. Check server logs."
+        )
 
 
 @router.post("/service/{action}", status_code=status.HTTP_204_NO_CONTENT)
@@ -103,4 +112,7 @@ async def control_service(action: str, _: User = Depends(get_current_admin)):
             case _:
                 raise HTTPException(400, detail=f"Unknown action: {action}")
     except WireGuardError as exc:
-        raise HTTPException(500, detail=str(exc))
+        logger.exception("WireGuard service action '%s' failed: %s", action, exc)
+        raise HTTPException(
+            500, detail="WireGuard service action failed. Check server logs."
+        )

--- a/backend/src/routers/smtp.py
+++ b/backend/src/routers/smtp.py
@@ -224,5 +224,7 @@ async def test_smtp_settings(
         logger.info("SMTP test email scheduled to %s", body.recipient)
 
     except Exception as exc:
-        logger.error("SMTP test failed: %s", exc)
-        raise HTTPException(500, detail=f"SMTP test failed: {exc!s}")
+        logger.exception("SMTP test failed: %s", exc)
+        raise HTTPException(
+            500, detail="SMTP test failed due to an internal error. Check server logs."
+        )

--- a/backend/src/routers/users.py
+++ b/backend/src/routers/users.py
@@ -14,12 +14,15 @@ router = APIRouter()
 
 
 async def _load_roles(db: AsyncSession, role_ids: list[int]) -> list[Role]:
-    roles = []
-    for rid in role_ids:
-        r = (await db.exec(select(Role).where(Role.id == rid))).one_or_none()
-        if r:
-            roles.append(r)
-    return roles
+    if not role_ids:
+        return []
+
+    result = await db.exec(select(Role).where(Role.id.in_(role_ids)))
+    roles = result.all()
+    role_by_id = {r.id: r for r in roles if r.id is not None}
+
+    # Keep the input order and silently ignore unknown role ids (current behavior).
+    return [role_by_id[rid] for rid in role_ids if rid in role_by_id]
 
 
 @router.get("", response_model=list[UserResponse])
@@ -98,6 +101,13 @@ async def update_user(
         raise HTTPException(404, detail="User not found")
 
     payload = data.model_dump(exclude_unset=True)
+    if "email" in payload and payload["email"] != u.email:
+        existing_user = (
+            await db.exec(select(User).where(User.email == payload["email"]))
+        ).one_or_none()
+        if existing_user:
+            raise HTTPException(422, detail="Email already in use")
+
     if "role_ids" in payload:
         u.roles = await _load_roles(db, payload.pop("role_ids"))
     u.sqlmodel_update(payload)


### PR DESCRIPTION
### Motivation
- Prevent accidental duplicate data and surface clearer errors when updating clients and users.
- Improve observability for server apply/service operations and SMTP test failures by logging full exceptions while returning safer client-facing messages.
- Optimize role loading to reduce per-role DB round-trips and preserve requested role ordering.

### Description
- Added uniqueness validation in `update_client` to check `name`, `email`, and `allocated_ips` before applying updates and return `422` for conflicts.
- Added an email uniqueness check in `update_user` to prevent duplicate user emails during patch operations.
- Rewrote `_load_roles` to batch-fetch roles with `select(Role).where(Role.id.in_(role_ids))`, preserve input order, and return an empty list early when `role_ids` is empty.
- Introduced a module `logger` in `server.py` and replaced raw exception details in `apply_config` and service control endpoints with logged exceptions and generic `500` messages for clients.
- Replaced `logger.error` with `logger.exception` in `smtp.test_smtp_settings` and returned a generic `500` error message to avoid leaking internals.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc327fa62c8330ac63b405a085341a)